### PR TITLE
AWSテキスト詳細ページ追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,11 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# Markdownの導入
+gem 'redcarpet', '~> 2.3.0'
+# シンタックスハイライト
+gem 'coderay'
+
 # デバッグ用のgem
 gem 'pry-byebug'
 gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -259,6 +260,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -271,6 +273,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
   rails-i18n
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@ main {
   padding: 1rem;
 }
 
+// awsテキスト教材
 #container  {
   margin: 0 auto;
   padding: 50px 0 160px 0;  
@@ -44,3 +45,8 @@ main {
   width: 50%;
 }
 
+// awsテキスト詳細ページ
+.aws_content{
+  width: 710px;
+  margin: 0 auto;
+}

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -4,4 +4,8 @@ class AwsTextsController < ApplicationController
     @awstexts = AwsText.all
   end
 
+  def show
+    @awstexts = AwsText.find(params[:id])
+  end
+  
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+      def block_code(code, language)
+          language = language.split(':')[0] if language.present?
+
+          case language.to_s
+          when 'rb'
+              lang = :ruby
+          when 'yml'
+              lang = :yaml
+          when 'css'
+              lang = :css
+          when 'html'
+              lang = :html
+          when ''
+              lang = :md
+          else
+              lang = language
+          end
+
+          CodeRay.scan(code, lang).div
+      end
+  end
+
+  def markdown(text)
+      html_render = HTMLwithCoderay.new(
+        filter_html: true,
+        hard_wrap: true,
+        link_attributes: { rel: 'nofollow', target: "_blank" }
+      )
+      options = {
+          autolink: true,
+          space_after_headers: true,
+          no_intra_emphasis: true,
+          fenced_code_blocks: true,
+          tables: true,
+          hard_wrap: true,
+          xhtml: true,
+          lax_html_blocks: true,
+          strikethrough: true
+      }
+      markdown = Redcarpet::Markdown.new(html_render, options)
+      markdown.render(text)
+  end
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -15,7 +15,7 @@
             <% @awstexts.each.with_index(1) do |awstext,i|%>
               <tr>
                 <td><%= i %></td>
-                <td><%= awstext.title %></td>
+                <td><%= link_to awstext.title,aws_text_path(awstext.id) %></td>
               </tr>
             <%end%>
           </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,4 @@
+<div class="aws_content">
+  <h2><%=@awstexts.title%></h2>
+  <p><%=markdown(@awstexts.content).html_safe%></p>
+</div>


### PR DESCRIPTION
【作業内容】
AWSテキスト詳細ページへのリンク・詳細ページの実装を行いました。

【参考資料】
逆転サロン　動画教材　「railsへのMarkdownの導入」
