### PR TITLE
22質問投稿ページ実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,7 @@ main {
 }
 
 // awsテキスト教材
-#container  {
+#container {
   margin: 0 auto;
   padding: 50px 0 160px 0;
 }
@@ -28,13 +28,13 @@ main {
   text-align: center;
 }
 
-.table-container{
+.table-container {
   width: 710px;
   margin: 0 auto;
 }
 
-.aws-table-head{
-  background-color: #5D99FF;
+.aws-table-head {
+  background-color: #5d99ff;
 }
 
 .w-1 {
@@ -46,25 +46,25 @@ main {
 }
 
 // awsテキスト詳細ページ
-.aws_content{
+.aws_content {
   width: 710px;
   margin: 0 auto;
 }
 
 // 動画教材ページ
-.text-center{
+.text-center {
   text-align: center;
 }
 
-.movie-title{
+.movie-title {
   font-size: 20px;
 }
 
-.movie-contents{
+.movie-contents {
   padding-bottom: 70px;
 }
 
-.pagination{
+.pagination {
   justify-content: center;
   padding-bottom: 140px;
 }
@@ -96,9 +96,9 @@ main {
 }
 
 .card-time {
-color: #a9a9a9;
-text-align: right;
-font-size: 17px;
+  color: #a9a9a9;
+  text-align: right;
+  font-size: 17px;
 }
 
 // フラッシュ
@@ -112,4 +112,23 @@ font-size: 17px;
 
 .alert-alert {
   @extend .alert-danger;
+}
+
+// questionページ
+.question-container {
+  width: 710px;
+}
+
+.question-container h1 {
+  padding: 20px 0 10px 0;
+  font-size: 30px;
+}
+
+.question-title,
+.question-detail {
+  display: block;
+}
+
+.form-control {
+  display: block;
 }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -2,4 +2,23 @@ class QuestionsController < ApplicationController
   def index
     @questions = Question.all
   end
+
+  def create
+    @question = Question.new(question_params)
+    if @question.save
+      flash[:notice]="登録に成功しました"
+      redirect_to action: :index
+    else
+      @questions = Question.all
+      render action: :index
+    end
+  end
+
+  private
+  def question_params
+    params.permit(:title,:detail)
+  end
+
+
+
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -13,6 +13,7 @@ class QuestionsController < ApplicationController
       flash[:notice]="登録に成功しました"
       redirect_to action: :index
     else
+      flash[:alert]="質問を入力してください"
       @questions = Question.all
       render action: :index
     end

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -16,6 +16,9 @@
       <div class="flash">
         <%= flash[:notice]%>
       </div>
+      <div class="flash">
+        <%= flash[:alert]%>
+      </div>
     <% end %>
   <%end%>
 </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,3 +1,25 @@
+<div class="question-container">
+  <h1>新規投稿</h1>
+  <%= form_with model: @question, local: true do |f|%>
+  <div class="form-group">
+    <p><%=f.label :"【質問】",class: 'question-title'%></p>
+    <%=f.text_area :title ,class: 'form-control',rows:3%>
+  </div>
+  <div class="form-group">
+    <%=f.label :"【詳細】",class: 'question-detail'%>
+    <%=f.text_area :detail ,class: 'form-control' ,rows:5%>
+  </div>
+  <div class="form-group">
+    <%=f.submit :"送信",class: 'btn btn-primary btn-block' %>
+  </div>
+      <% if flash[:notice]%>
+      <div class="flash">
+        <%= flash[:notice]%>
+      </div>
+    <% end %>
+  <%end%>
+</div>
+
 <% @questions.each do |question|%>
   <div class="card w-90">
     <a href="#">


### PR DESCRIPTION
【作業内容】
・質問を投稿し、一覧に表示されるようにしました。
・bootstrap等を用いページの逆転教材に似せました。

【参考資料】
・qiita「https://qiita.com/snskOgata/items/44d32a06045e6a52d11c#2-form_with%E3%81%AE%E5%8B%95%E4%BD%9C%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6」
・逆転テキスト教材「bootstrap」